### PR TITLE
Refactor support card detail

### DIFF
--- a/src/components/EventDetail/EventDetail.tsx
+++ b/src/components/EventDetail/EventDetail.tsx
@@ -1,12 +1,9 @@
 import { AccordionDetails, Card, CardContent, Typography } from "@material-ui/core"
-type EventChoice = {
-  title: string
-  effect: string
-}
+import { CardEventChoice } from "../../types"
 
 type Props = {
-  title: string | null | undefined
-  choice: EventChoice[] | undefined | null
+  title: string
+  choice: CardEventChoice[]
 }
 
 const EventDetail: React.FC<Props> = (props: Props) => {

--- a/src/components/SupportCardDetail/SupportCardDetail.tsx
+++ b/src/components/SupportCardDetail/SupportCardDetail.tsx
@@ -1,11 +1,14 @@
 import { Accordion, AccordionSummary, Avatar, createStyles, makeStyles, Theme, Typography } from "@material-ui/core"
 import { ExpandMore } from "@material-ui/icons"
-import React from "react"
-import { GetSupportCardOnIdWithEventQuery } from "../../generated/graphql"
+import React, { useContext } from "react"
+import { UriContext } from "../../common"
+import { CardEventWithChoice } from "../../types"
 import EventDetail from "../EventDetail"
 
 type Props = {
-  cards: GetSupportCardOnIdWithEventQuery
+  supportCardTitle: string,
+  cardImage: string,
+  event: CardEventWithChoice[]
 }
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -22,30 +25,24 @@ const useStyles = makeStyles((theme: Theme) =>
 
 const SupportCardDetail: React.FC<Props> = (props: Props) => {
   const classes = useStyles();
-  if (props.cards.supportCardId == null) return <></>
-  const supportCard = props.cards.supportCardId
-  const cardEvents = supportCard.cardEvent?.edges.map(x => x?.node)
+  const { supportCardTitle, event, cardImage } = props;
+  const uri = useContext(UriContext);
 
   return <div>
-    <Avatar alt={props.cards.supportCardId.cardName!} src={`http://localhost:5000/images/${props.cards.supportCardId.cardImage}`} />
+    <Avatar alt={supportCardTitle} src={`${uri}/images/${cardImage}`} />
     {
-      cardEvents?.map((x, i) => {
+      event.map((x, i) => {
         return <Accordion>
           <AccordionSummary
             expandIcon={<ExpandMore />}
             aria-controls="panel1a-content"
             id="panel1a-header"
           >
-            <Typography className={classes.heading}>{x?.title}</Typography>
+            <Typography className={classes.heading}>{x.title}</Typography>
           </AccordionSummary>
           <EventDetail
-            title={x?.title}
-            choice={
-              x?.cardEventChoice?.edges
-                .filter(x => x?.node != null)
-                .map(x => { return { title: x!.node!.title!, effect: x!.node!.effect! } })
-            } />
-
+            title={x.title}
+            choice={x.choices} />
         </Accordion>
       })
     }

--- a/src/components/SupportCardDetail/SupportCardDetailContainer.tsx
+++ b/src/components/SupportCardDetail/SupportCardDetailContainer.tsx
@@ -1,5 +1,6 @@
 import gql from "graphql-tag";
 import { useGetSupportCardOnIdWithEventQuery } from "../../generated/graphql";
+import { CardEventChoice, CardEventWithChoice } from "../../types";
 import { CARD_EVENT_FIELD_WITH_CHOICES } from "../common/fragments";
 import SupportCardDetail from "./SupportCardDetail";
 
@@ -23,9 +24,26 @@ const SupportCardDetailContainer: React.FC<Props> = (props: Props) => {
   });
   if(loading) return (<p>loading...</p>)
   if(error) return (<p>error</p>)
-  if(data === undefined || data.supportCardId === undefined) return (<p>data not exist</p>)
+  if(data == null || data?.supportCardId == null) return (<p>data not exist</p>)
+  
+  const events = data?.supportCardId?.cardEvent?.edges
 
-  return <SupportCardDetail cards={data} />
+  if(events == null) return (<p>data not exist</p>)
+
+  const eventWithChoice = events.map(x => { return {
+     title: x?.node?.title!,
+     choices: x?.node?.cardEventChoice?.edges!
+      .map(x => { return {
+        title: x?.node?.title!,
+        effect: x?.node?.effect!
+      } as CardEventChoice
+    })
+  } as CardEventWithChoice });
+
+  return <SupportCardDetail 
+    supportCardTitle={data.supportCardId.cardName!}
+    cardImage={data.supportCardId.cardImage!}
+    event={eventWithChoice} />
 }
 
 export default SupportCardDetailContainer

--- a/src/components/SupportCardList/SupportCard/SupportCard.tsx
+++ b/src/components/SupportCardList/SupportCard/SupportCard.tsx
@@ -1,15 +1,7 @@
 import React, { useContext } from "react";
 import { UriContext } from "../../../common";
+import { SupportCard } from "../../../types";
 import "./SupportCard.css";
-
-export type SupportCard = {
-  uuid: number
-  cardName: string,
-  secondName: string,
-  rareDegree: string,
-  cardImage: string,
-  cardType: string,
-}
 
 type Props = SupportCard & {
   onClickItem: (uuid: number) => void

--- a/src/components/SupportCardList/SupportCard/index.ts
+++ b/src/components/SupportCardList/SupportCard/index.ts
@@ -1,5 +1,3 @@
 import SupportCardComponent from "./SupportCard";
-import SupportCard from "./SupportCard";
 
-export { SupportCard }
 export default SupportCardComponent

--- a/src/components/SupportCardList/SupportCardList.tsx
+++ b/src/components/SupportCardList/SupportCardList.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import SupportCardComponent, { SupportCard } from "./SupportCard/SupportCard";
+import SupportCardComponent from "./SupportCard/SupportCard";
+import { SupportCard } from "../../types";
 import "./SupportCardList.css";
 
 type Props = {

--- a/src/components/SupportCardList/SupportCardListContainer.tsx
+++ b/src/components/SupportCardList/SupportCardListContainer.tsx
@@ -2,7 +2,7 @@ import gql from "graphql-tag";
 import React from "react";
 import { useSupportCardQuery } from "../../generated/graphql";
 import { CORE_SUPPORT_CARD_FIELD } from "../common/fragments";
-import { SupportCard } from "./SupportCard/SupportCard";
+import { SupportCard } from "../../types";
 import SupportCardList from "./SupportCardList";
 import "./SupportCardListContainer.css";
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,21 @@
+export type CardEventChoice = {
+  title: string;
+  effect: string;
+}
+
+export type CardEvent = {
+  title: string;
+}
+
+export type SupportCard = {
+  uuid: number;
+  cardName: string;
+  secondName: string;
+  rareDegree: "SSR" | "SR" | "R";
+  cardImage: string;
+  cardType: string;
+};
+
+export type CardEventWithChoice = CardEvent & {
+  choices: CardEventChoice[];
+};


### PR DESCRIPTION
이전에는 `SupportCardComponent` 안에서 데이터를 가공하고는 했었으나, 이는 컴포넌트를 테스트 용이하지 않고 유지보수하기 힘들게 만드므로 이를 `SupportCardContainer` 로 옮기고 `SupportCardComponent` 는 단순 데이터 구조만을 받게 변경하였습니다. 