### PR TITLE
Show only 2 more choices on play page

### DIFF
--- a/src/components/EventDetail/EventDetail.tsx
+++ b/src/components/EventDetail/EventDetail.tsx
@@ -14,7 +14,7 @@ const EventDetail: React.FC<Props> = (props: Props) => {
   return <AccordionDetails>
     {
       props.choice.map((x, i) => {
-        return <Card>
+        return <Card key={i}>
           <CardContent>
           <Typography variant="h5" component="h2">
             {x.title}

--- a/src/components/SupportCardDetail/SupportCardDetail.tsx
+++ b/src/components/SupportCardDetail/SupportCardDetail.tsx
@@ -32,7 +32,7 @@ const SupportCardDetail: React.FC<Props> = (props: Props) => {
     <Avatar alt={supportCardTitle} src={`${uri}/images/${cardImage}`} />
     {
       event.map((x, i) => {
-        return <Accordion>
+        return <Accordion key={i}>
           <AccordionSummary
             expandIcon={<ExpandMore />}
             aria-controls="panel1a-content"

--- a/src/components/SupportCardDetail/SupportCardDetailContainer.tsx
+++ b/src/components/SupportCardDetail/SupportCardDetailContainer.tsx
@@ -26,11 +26,11 @@ const SupportCardDetailContainer: React.FC<Props> = (props: Props) => {
   if(error) return (<p>error</p>)
   if(data == null || data?.supportCardId == null) return (<p>data not exist</p>)
   
-  const events = data?.supportCardId?.cardEvent?.edges
+  const rawEvents = data?.supportCardId?.cardEvent?.edges
 
-  if(events == null) return (<p>data not exist</p>)
+  if(rawEvents == null) return (<p>data not exist</p>)
 
-  const eventWithChoice = events.map(x => { return {
+  const events = rawEvents.map(x => { return {
      title: x?.node?.title!,
      choices: x?.node?.cardEventChoice?.edges!
       .map(x => { return {
@@ -38,12 +38,12 @@ const SupportCardDetailContainer: React.FC<Props> = (props: Props) => {
         effect: x?.node?.effect!
       } as CardEventChoice
     })
-  } as CardEventWithChoice });
+  } as CardEventWithChoice }).filter(x => x.choices.length > 1);
 
   return <SupportCardDetail 
     supportCardTitle={data.supportCardId.cardName!}
     cardImage={data.supportCardId.cardImage!}
-    event={eventWithChoice} />
+    event={events} />
 }
 
 export default SupportCardDetailContainer

--- a/src/pages/Play/Play.tsx
+++ b/src/pages/Play/Play.tsx
@@ -12,8 +12,8 @@ const Play: React.FC<RouteComponentProps> = (props: RouteComponentProps) => {
   return (
     <>
       {
-        selectedList.map(x =>
-          <SupportCardDetailContainer uuid={x} />
+        selectedList.map((x, i) =>
+          <SupportCardDetailContainer uuid={x} key={i} />
         )
       }
     </>


### PR DESCRIPTION
사실 1개짜리 선택지를 가지고 있는 이벤트들은 리스트에 나와 봐야 별로 쓸모가 없습니다.
따라서 2개 이상의 선택지가 있는 이벤트들만 페이지에 나오게 합니다.

덤으로 key prop 이 누락되어 에러가 발생하던 점도 수정하였습니다.