### PR TITLE
Fix baseUri on netlify deploy previews

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -2,7 +2,13 @@ import { createContext } from "react"
 
 let production = process.env.NODE_ENV === 'production';
 let uri;
-if(production) {
+
+if(process.env.URL) {
+  // https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata
+  // Required for Netlify Deploy Preview to perform correctly.
+  uri = process.env.URL
+}
+else if(production) {
   uri = 'https://uma.hitagi.moe'
 }
 else {

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,18 +1,4 @@
 import { createContext } from "react"
 
-let production = process.env.NODE_ENV === 'production';
-let uri;
-
-if(process.env.URL) {
-  // https://docs.netlify.com/configure-builds/environment-variables/#deploy-urls-and-metadata
-  // Required for Netlify Deploy Preview to perform correctly.
-  uri = process.env.URL
-}
-else if(production) {
-  uri = 'https://uma.hitagi.moe'
-}
-else {
-  uri = 'http://localhost:5000'
-}
-export const baseUri = uri
-export const UriContext = createContext(uri)
+export const baseUri = document.baseURI
+export const UriContext = createContext(baseUri)


### PR DESCRIPTION
baseUri이 하드코딩되어 있는 상황이라 Deploy Preview URL과 일치하지 않는 문제가 있어, Netlify에서 제공하는 환경 변수를 우선하도록 수정했습니다.